### PR TITLE
chore: update module with new jsii writeAssembly function

### DIFF
--- a/src/assemblies.ts
+++ b/src/assemblies.ts
@@ -1,18 +1,14 @@
 import * as path from 'path';
-import * as spec from '@jsii/spec';
+import { Assembly, Type, writeAssembly, compressedAssemblyExists } from '@jsii/spec';
 import * as fs from 'fs-extra';
 import { FIXTURE_NAME } from './generate-missing-examples';
 
 /**
  * Replaces the file where the original assembly file *should* be found with a new assembly file.
- * Recalculates the fingerprint of the assembly to avoid tampering detection.
+ * Detects whether or not there is a compressed assembly, and if there is, compresses the new assembly also.
  */
-export async function replaceAssembly(assembly: spec.Assembly, directory: string): Promise<void> {
-  const fileName = path.join(directory, '.jsii');
-  await fs.writeJson(fileName, _fingerprint(assembly), {
-    encoding: 'utf8',
-    spaces: 2,
-  });
+export function replaceAssembly(assembly: Assembly, directory: string) {
+  writeAssembly(directory, _fingerprint(assembly), { compress: compressedAssemblyExists(directory) });
 }
 
 export function addFixtureToRosetta(directory: string, fileName: string, fixture: string) {
@@ -35,7 +31,7 @@ export function addFixtureToRosetta(directory: string, fileName: string, fixture
  * or spending extra time calculating a new fingerprint, we replace with '**********'
  * that demonstrates the fingerprint has changed.
  */
-function _fingerprint(assembly: spec.Assembly): spec.Assembly {
+function _fingerprint(assembly: Assembly): Assembly {
   assembly.fingerprint = '*'.repeat(10);
   return assembly;
 }
@@ -43,7 +39,7 @@ function _fingerprint(assembly: spec.Assembly): spec.Assembly {
 /**
  * Insert an example into the docs of a type
  */
-export function insertExample(visibleSource: string, type: spec.Type): void {
+export function insertExample(visibleSource: string, type: Type): void {
   if (type.docs) {
     type.docs.example = visibleSource;
   } else {

--- a/src/generate-missing-examples.ts
+++ b/src/generate-missing-examples.ts
@@ -80,8 +80,7 @@ export async function generateMissingExamples(assemblyLocations: string[], optio
   });
 
   console.log(`Saving ${loadedAssemblies.length} assemblies`);
-  await Promise.all((loadedAssemblies).map(({ assembly, assemblyLocation }) =>
-    replaceAssembly(assembly.spec, assemblyLocation)));
+  loadedAssemblies.map(({ assembly, assemblyLocation }) => replaceAssembly(assembly.spec, assemblyLocation));
 
   // extract snippets if extract flag is set.
   if (options.extractOptions) {

--- a/test/generate-missing-examples.test.ts
+++ b/test/generate-missing-examples.test.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import { SPEC_FILE_NAME, SPEC_FILE_NAME_COMPRESSED } from '@jsii/spec';
 import * as fs from 'fs-extra';
 
 import { LanguageTablet, TargetLanguage } from 'jsii-rosetta';
@@ -70,6 +71,79 @@ test('test end-to-end and translation to Python', async () => {
       },
     });
 
+    const tablet = await LanguageTablet.fromFile(outputTablet);
+
+    const pythons = tablet.snippetKeys
+      .map((key) => tablet.tryGetSnippet(key)!)
+      .map((snip) => snip.get(TargetLanguage.PYTHON)?.source);
+
+    const classInstantiation = pythons.find((s) => s?.includes('= my_assembly.MyClass('));
+    expect(classInstantiation).toEqual([
+      '# The code below shows an example of how to instantiate this type.',
+      '# The values are placeholders you should change.',
+      'import example_test_demo as my_assembly',
+      '',
+      'my_class = my_assembly.MyClass(\"value\",',
+      '    some_number=123,',
+      '    some_string=\"someString\"',
+      ')',
+    ].join('\n'));
+  } finally {
+    await assembly.cleanup();
+  }
+});
+
+test('test end-to-end and translation to Python with compressed assembly', async () => {
+  const assembly = await AssemblyFixture.fromSource(
+    {
+      'index.ts': `
+      export interface MyClassProps {
+        readonly someString: string;
+        readonly someNumber: number;
+      }
+
+      export class MyClass {
+        constructor(value: string, props: MyClassProps) {
+          Array.isArray(value);
+          Array.isArray(props);
+        }
+      }
+    `,
+    },
+    {
+      name: 'my_assembly',
+      jsii: DUMMY_ASSEMBLY_TARGETS,
+    },
+    {
+      compressAssembly: true,
+    },
+  );
+  try {
+    // ensure the compressed assembly exists and the file at SPEC_FILE_NAME is a redirect schema
+    expect(fs.existsSync(path.join(assembly.directory, SPEC_FILE_NAME_COMPRESSED))).toBeTruthy();
+    const schema = await fs.readJson(path.join(assembly.directory, SPEC_FILE_NAME), { encoding: 'utf-8' });
+    expect(schema).toEqual({
+      schema: 'jsii/file-redirect',
+      compression: 'gzip',
+      filename: SPEC_FILE_NAME_COMPRESSED,
+    });
+
+    const outputTablet = path.join(assembly.directory, 'test.tbl.json');
+
+    await generateMissingExamples([assembly.directory], {
+      extractOptions: {
+        cache: outputTablet,
+      },
+    });
+
+    // ensure the file at SPEC_FILE_NAME is still a redirect schema
+    expect(await fs.readJson(path.join(assembly.directory, SPEC_FILE_NAME), { encoding: 'utf-8' })).toEqual({
+      schema: 'jsii/file-redirect',
+      compression: 'gzip',
+      filename: SPEC_FILE_NAME_COMPRESSED,
+    });
+
+    // ensure translations still work as expected
     const tablet = await LanguageTablet.fromFile(outputTablet);
 
     const pythons = tablet.snippetKeys


### PR DESCRIPTION
Updates `cdk-generate-synthetic-examples` to use the functions introduced in https://github.com/aws/jsii/pull/3570 where appropriate.