### PR TITLE
chore: refactor replaceAssembly so that it is imported from @jsii/spec

### DIFF
--- a/src/assemblies.ts
+++ b/src/assemblies.ts
@@ -1,15 +1,7 @@
 import * as path from 'path';
-import { Assembly, Type, writeAssembly, compressedAssemblyExists } from '@jsii/spec';
+import { Type } from '@jsii/spec';
 import * as fs from 'fs-extra';
 import { FIXTURE_NAME } from './generate-missing-examples';
-
-/**
- * Replaces the file where the original assembly file *should* be found with a new assembly file.
- * Detects whether or not there is a compressed assembly, and if there is, compresses the new assembly also.
- */
-export function replaceAssembly(assembly: Assembly, directory: string) {
-  writeAssembly(directory, _fingerprint(assembly), { compress: compressedAssemblyExists(directory) });
-}
 
 export function addFixtureToRosetta(directory: string, fileName: string, fixture: string) {
   const rosettaPath = path.join(directory, 'rosetta');
@@ -21,19 +13,6 @@ export function addFixtureToRosetta(directory: string, fileName: string, fixture
     return;
   }
   fs.writeFileSync(filePath, fixture);
-}
-
-/**
- * Replaces the old fingerprint with '***********'.
- *
- * @rmuller says fingerprinting is useless, as we do not actually check
- * if an assembly is changed. Instead of keeping the old (wrong) fingerprint
- * or spending extra time calculating a new fingerprint, we replace with '**********'
- * that demonstrates the fingerprint has changed.
- */
-function _fingerprint(assembly: Assembly): Assembly {
-  assembly.fingerprint = '*'.repeat(10);
-  return assembly;
 }
 
 /**

--- a/src/generate-missing-examples.ts
+++ b/src/generate-missing-examples.ts
@@ -1,9 +1,10 @@
 /* eslint-disable no-console */
 import { promises as fs } from 'fs';
+import { replaceAssembly } from '@jsii/spec';
 import { Assembly, ClassType, InterfaceType, TypeSystem } from 'jsii-reflect';
 
 import { extractSnippets } from 'jsii-rosetta/lib/commands/extract';
-import { insertExample, replaceAssembly, addFixtureToRosetta } from './assemblies';
+import { insertExample, addFixtureToRosetta } from './assemblies';
 import { generateAssignmentStatement } from './generate';
 
 const COMMENT_WARNING = [


### PR DESCRIPTION
jsii v1.64.0 exports a new `replaceAssembly` method that serves as a source-of-truth for all libraries that replaces the assembly file. This will be easier to track any changes to the `replaceAssembly` function in the future.