### PR TITLE
fix: generated examples fail when scope is not of type `Construct`

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -175,7 +175,11 @@ function generateStaticFactoryPropertyExample(staticFactoryProperty: reflect.Pro
  * Generate an example value of the given parameter.
  */
 function exampleValueForParameter(context: ExampleContext, param: reflect.Parameter, position: number, level: number): Code {
-  if (param.name === 'scope' && position === 0) {
+  if (
+    param.name === 'scope' &&
+    ['constructs.IConstruct', 'constructs.Construct'].includes(param.type.fqn ?? '') &&
+    position === 0
+  ) {
     return new Code('this');
   }
 

--- a/test/generate.test.ts
+++ b/test/generate.test.ts
@@ -93,7 +93,7 @@ describe('generateClassAssignment ', () => {
         'declare const prop5: any;',
         'declare const property: my_assembly.Property;',
         '',
-        'const classA = new my_assembly.ClassA(this, \'MyClassA\', {',
+        'const classA = new my_assembly.ClassA(\'scope\', \'MyClassA\', {',
         '  prop1: 123,',
         '  prop2: property,',
         '  prop3: [\'prop3\'],',
@@ -150,7 +150,7 @@ describe('generateClassAssignment ', () => {
       expected: [
         'import * as my_assembly from \'my_assembly\';',
         '',
-        'const classA = new my_assembly.ClassA(this, \'MyClassA\', {',
+        'const classA = new my_assembly.ClassA(\'scope\', \'MyClassA\', {',
         '  prop1: 123,',
         '',
         '  // the properties below are optional',
@@ -178,7 +178,7 @@ describe('generateClassAssignment ', () => {
       expected: [
         'import * as my_assembly from \'my_assembly\';',
         '',
-        'const classA = new my_assembly.ClassA(this, \'MyClassA\', /* all optional props */ {',
+        'const classA = new my_assembly.ClassA(\'scope\', \'MyClassA\', /* all optional props */ {',
         '  prop1: 123,',
         '  prop2: 123,',
         '});',


### PR DESCRIPTION
In the generated fixture, `this` is of type construct:

```ts
import { Construct } from "constructs";
class MyConstruct extends Construct {
constructor(scope: Construct, id: string) {
super(scope, id);
/// here
} }
```

Therefore we can only supply `this` when the type is the same. Notably, the generated examples fail when the type is an App:

```bash
@aws-cdk.app-staging-synthesizer-alpha.DefaultStagingStack-example.ts:20:83 - error TS2345: Argument of type 'this' is not assignable to parameter of type 'App'.

const defaultStagingStack = new app_staging_synthesizer_alpha.DefaultStagingStack(this, 'MyDefaultStagingStack', {
```