### PR TITLE
fix: don't emit examples larger than 500 lines

### DIFF
--- a/src/generate-missing-examples.ts
+++ b/src/generate-missing-examples.ts
@@ -5,12 +5,7 @@ import { Assembly, ClassType, InterfaceType, TypeSystem } from 'jsii-reflect';
 
 import { extractSnippets } from 'jsii-rosetta/lib/commands/extract';
 import { insertExample, addFixtureToRosetta } from './assemblies';
-import { generateAssignmentStatement } from './generate';
-
-const COMMENT_WARNING = [
-  '// The code below shows an example of how to instantiate this type.',
-  '// The values are placeholders you should change.',
-];
+import { generateExample } from './generate';
 
 export const FIXTURE_NAME = '_generated';
 
@@ -56,17 +51,11 @@ export async function generateMissingExamples(assemblyLocations: string[], optio
 
     const failed = new Array<string>();
     const generatedSnippets = documentableTypes.flatMap((classType) => {
-      const example = generateAssignmentStatement(classType);
-      if (!example) {
+      const visibleSource = generateExample(classType);
+      if (visibleSource === undefined) {
         failed.push(classType.name);
         return [];
       }
-
-      const visibleSource = [
-        ...COMMENT_WARNING,
-        ...example.renderDeclarations(),
-        example.renderCode(),
-      ].join('\n').trimLeft();
 
       insertExample(visibleSource, classType.spec);
       return [visibleSource];

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -15,6 +15,18 @@ const SPECIAL_TYPE_EXAMPLES: Record<string, string> = {
   'aws-cdk-lib.Duration': 'cdk.Duration.minutes(30)',
 };
 
+const COMMENT_WARNING = [
+  '// The code below shows an example of how to instantiate this type.',
+  '// The values are placeholders you should change.',
+];
+
+const MAX_EXAMPLE_LINES = 500;
+
+const TOO_LARGE_WARNING = [
+  `// The generated example for this type would exceed ${MAX_EXAMPLE_LINES} lines,`,
+  '// and has been elided for readability.',
+];
+
 /**
  * Context on the example that we are building.
  * This object persists throughout the recursive call
@@ -37,6 +49,25 @@ class ExampleContext {
   public get rendered() {
     return this._rendered;
   }
+}
+
+export function generateExample(classType: reflect.ClassType | reflect.InterfaceType): string | undefined {
+  const example = generateAssignmentStatement(classType);
+  if (!example) {
+    return undefined;
+  }
+
+  const rendered = [
+    ...COMMENT_WARNING,
+    ...example.renderDeclarations(),
+    example.renderCode(),
+  ].join('\n').trimStart();
+
+  if (rendered.split('\n').length > MAX_EXAMPLE_LINES) {
+    return TOO_LARGE_WARNING.join('\n');
+  }
+
+  return rendered;
 }
 
 export function generateAssignmentStatement(type: reflect.ClassType | reflect.InterfaceType): Code | undefined {


### PR DESCRIPTION
Currently, the `aws-quicksight` library would produce an example that is 30,000 lines. There is no real point to this and in fact blows up the size of the Python source file by quite a lot, so refuse to generate examples that are too large.

In the future we may choose to do this eliding more intelligently (for example, by skipping optional properties and/or limiting recursion depth), but this is a multidimensional optimization problem that may not be so simple to solve as it seems at first. Most important thing is to stop the bleeding.

Fixes #