### PR TITLE
fix: protected methods erroneously referenced in example generation

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -143,7 +143,7 @@ function getAccessibleConstructor(classType: reflect.ClassType): reflect.Initial
  */
 function getStaticFactoryMethods(classType: reflect.ClassType): reflect.Method[] {
   return classType.allMethods.filter(method =>
-    method.static && extendsRef(classType, method.returns.type),
+    method.static && !method.protected && extendsRef(classType, method.returns.type),
   );
 }
 
@@ -152,7 +152,7 @@ function getStaticFactoryMethods(classType: reflect.ClassType): reflect.Method[]
  */
 function getStaticFactoryProperties(classType: reflect.ClassType): reflect.Property[] {
   return classType.allProperties.filter(prop =>
-    prop.static && extendsRef(classType, prop.type),
+    prop.static && !prop.protected && extendsRef(classType, prop.type),
   );
 }
 

--- a/test/generate.test.ts
+++ b/test/generate.test.ts
@@ -152,7 +152,7 @@ describe('generateClassAssignment ', () => {
     await assembly.cleanup();
   });
 
-  test('returns undefined for protected methods', async () => {
+  test('returns undefined when only protected/private methods present', async () => {
     const assembly = await AssemblyFixture.fromSource(
       {
         'index.ts': `

--- a/test/generate.test.ts
+++ b/test/generate.test.ts
@@ -61,7 +61,7 @@ describe('generateClassAssignment ', () => {
     }),
   );
 
-  test('blah',
+  test('generates example that ignores protected static method',
     expectedDocTest({
       sources: {
         'index.ts': `


### PR DESCRIPTION
protected methods show up in the assembly (private methods do not). they cannot be used in example generation however.

seeing an error in the pipeline with `fromDeploymentConfigName` since its a protected static method.

```bash
const baseDeploymentConfig = codedeploy.BaseDeploymentConfig.fromDeploymentConfigName(this, 'MyBaseDeploymentConfig', 'deploymentConfigName');
```