### PR TITLE
fix: class with property bag that references the class generates incorrect example

### DIFF
--- a/test/generate.test.ts
+++ b/test/generate.test.ts
@@ -61,6 +61,31 @@ describe('generateClassAssignment ', () => {
     }),
   );
 
+  test('generates example for class that references itself',
+    expectedDocTest({
+      sources: {
+        'index.ts': `
+        export class ClassA {
+          public constructor(public readonly props: ClassAProps) {}
+        }
+        export interface ClassAProps {
+          readonly parentClass: ClassA,
+        }
+        `,
+      },
+      typeName: 'ClassA',
+      expected: [
+        'import * as my_assembly from \'my_assembly\';',
+        '',
+        'declare const classA_: my_assembly.ClassA;',
+        '',
+        'const classA = new my_assembly.ClassA({',
+        '  parentClass: classA_,',
+        '});',
+      ],
+    }),
+  );
+
   test('generates example for more complicated class instantiation',
     expectedDocTest({
       sources: {


### PR DESCRIPTION
We previously implemented a recursion breaker on structs to account for scenarios like:

```ts
export interface Props {
  props: Props,
}
```

We didn't add the recursion breaker for a similar scenario:

```ts
export class ClassA {
  public constructor(props: Props) {}
}

export interface Props {
  class: ClassA,
}
```

The issue is that we have a well-defined way of naming properties which breaks in this scenario. We previously would render this (uncompilable) example:

```ts
const classA = new ClassA({
  class: classA,
});
```

Since it references itself before initiation. This PR changes it to the following example:

```ts
declare const classA_: ClassA;
const classA = new ClassA({
  class: classA_,
});
```

