### PR TITLE
feat!: jsii-rosetta peer dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,3 +80,37 @@ jobs:
           git add .
           git commit -s -m "chore: self mutation"
           git push origin HEAD:$PULL_REQUEST_REF
+  rosetta-compat:
+    runs-on: ubuntu-latest
+    permissions: {}
+    env:
+      CI: "true"
+      NODE_OPTIONS: --max_old_space_size=4096
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - name: Install dependencies
+        run: yarn install --check-files
+      - name: Install Rosetta version
+        run: yarn add --dev jsii-rosetta@${{ matrix.rosetta }}
+      - name: compile+test
+        run: |-
+          npx projen compile
+          npx projen test
+      - name: Check Rosetta version
+        run: test $(npx jsii-rosetta --version) = "${{ matrix.rosetta }}"
+    strategy:
+      matrix:
+        rosetta:
+          - 1.85.0
+          - 5.1.2
+          - 5.2.0
+          - 5.3.0
+          - 5.4.0

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -59,7 +59,16 @@
       "type": "build"
     },
     {
+      "name": "jsii-rosetta",
+      "version": "^1.85.0 || ~5.1.2 || ~5.2.0 || ~5.3.0 || ~5.4.0",
+      "type": "build"
+    },
+    {
       "name": "projen",
+      "type": "build"
+    },
+    {
+      "name": "semver",
       "type": "build"
     },
     {
@@ -85,10 +94,6 @@
     },
     {
       "name": "jsii-reflect",
-      "type": "runtime"
-    },
-    {
-      "name": "jsii-rosetta",
       "type": "runtime"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -227,13 +227,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=prod --filter=@jsii/spec,jsii-reflect,jsii-rosetta,yargs"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=prod --filter=@jsii/spec,jsii-reflect,yargs"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @jsii/spec jsii-reflect jsii-rosetta yargs"
+          "exec": "yarn upgrade @jsii/spec jsii-reflect yargs"
         },
         {
           "exec": "npx projen"
@@ -275,13 +275,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/yargs,cdklabs-projen-project-types,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii,projen,ts-jest,ts-node,typescript"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=@types/jest,@types/yargs,cdklabs-projen-project-types,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii,projen,semver,ts-jest,ts-node,typescript"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @types/jest @types/node @types/yargs @typescript-eslint/eslint-plugin @typescript-eslint/parser cdklabs-projen-project-types constructs eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jsii projen standard-version ts-jest ts-node typescript"
+          "exec": "yarn upgrade @types/jest @types/node @types/yargs @typescript-eslint/eslint-plugin @typescript-eslint/parser cdklabs-projen-project-types constructs eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jsii jsii-rosetta projen semver standard-version ts-jest ts-node typescript"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,4 +1,5 @@
 import { CdklabsTypeScriptProject } from 'cdklabs-projen-project-types';
+import { RosettaPeerDependency, RosettaVersionLines } from './projenrc/rosetta';
 
 const project = new CdklabsTypeScriptProject({
   projenrcTs: true,
@@ -10,7 +11,6 @@ const project = new CdklabsTypeScriptProject({
   deps: [
     '@jsii/spec',
     'jsii-reflect',
-    'jsii-rosetta',
     'yargs',
   ],
   devDeps: [
@@ -21,11 +21,28 @@ const project = new CdklabsTypeScriptProject({
     'jsii',
     'typescript',
   ],
+  tsconfig: {
+    compilerOptions: {
+      skipLibCheck: true,
+    },
+  },
   releaseToNpm: true,
   gitignore: ['*.js', '*.d.ts'],
   workflowNodeVersion: '18.x',
   enablePRAutoMerge: true,
   setNodeEngineVersion: false,
+});
+
+// Add the new version line here
+new RosettaPeerDependency(project, {
+  supportedVersions: {
+    [RosettaVersionLines.V1_X]: '^1.85.0',
+    [RosettaVersionLines.V5_0]: false,
+    [RosettaVersionLines.V5_1]: '~5.1.2',
+    [RosettaVersionLines.V5_2]: '~5.2.0',
+    [RosettaVersionLines.V5_3]: '~5.3.0',
+    [RosettaVersionLines.V5_4]: '~5.4.0',
+  },
 });
 
 project.synth();

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
     "jest": "^29",
     "jest-junit": "^15",
     "jsii": "^5.4.6",
+    "jsii-rosetta": "^1.85.0 || ~5.1.2 || ~5.2.0 || ~5.3.0 || ~5.4.0",
     "projen": "^0.81.1",
+    "semver": "^7.6.0",
     "standard-version": "^9",
     "ts-jest": "^29",
     "ts-node": "^10.9.2",
@@ -58,7 +60,6 @@
   "dependencies": {
     "@jsii/spec": "^1.97.0",
     "jsii-reflect": "^1.97.0",
-    "jsii-rosetta": "^1.97.0",
     "yargs": "^17.7.2"
   },
   "main": "lib/index.js",

--- a/projenrc/rosetta.ts
+++ b/projenrc/rosetta.ts
@@ -1,0 +1,103 @@
+import { Component, DependencyType, typescript } from 'projen';
+import { minVersion } from 'semver';
+
+const JSII_ROSETTA = 'jsii-rosetta';
+
+export enum RosettaVersionLines {
+  V1_X,
+  V5_0,
+  V5_1,
+  V5_2,
+  V5_3,
+  V5_4,
+}
+
+export interface RosettaPeerDependencyOptions {
+  /**
+   * Provide the semver constraint for supported version for each Rosetta version line
+   * Set `false` to disable support for a version line.
+   */
+  readonly supportedVersions: Record<RosettaVersionLines, string | false>;
+}
+
+export class RosettaPeerDependency extends Component {
+  public constructor(project: typescript.TypeScriptProject, options: RosettaPeerDependencyOptions) {
+    super(project);
+
+    // this needs semver
+    project.addDevDeps('semver');
+
+    // clear out any other rosetta deps
+    const constraint = this.calculateVersionConstraint(options.supportedVersions);
+    project.deps.addDependency(constraint, DependencyType.PEER);
+    project.deps.removeDependency('jsii-rosetta');
+    project.deps.addDependency(constraint, DependencyType.BUILD);
+
+    project.github?.tryFindWorkflow('build')?.addJob('rosetta-compat', {
+      runsOn: ['ubuntu-latest'],
+      permissions: {},
+      env: {
+        CI: 'true',
+        NODE_OPTIONS: '--max_old_space_size=4096',
+      },
+      strategy: {
+        matrix: {
+          domain: {
+            rosetta: this.calculateMinimalVersions(options.supportedVersions),
+          },
+        },
+      },
+      steps: [{
+        name: 'Checkout',
+        uses: 'actions/checkout@v3',
+        with: {
+          ref: '${{ github.event.pull_request.head.ref }}',
+          repository: '${{ github.event.pull_request.head.repo.full_name }}',
+        },
+      },
+      {
+        name: 'Setup Node.js',
+        uses: 'actions/setup-node@v3',
+        with: {
+          // @ts-ignore
+          'node-version': project.nodeVersion,
+        },
+      },
+      {
+        name: 'Install dependencies',
+        run: 'yarn install --check-files',
+      },
+      {
+        name: 'Install Rosetta version',
+        run: `yarn add --dev ${JSII_ROSETTA}@\${{ matrix.rosetta }}`,
+      },
+      {
+        name: 'compile+test',
+        run: ['npx projen compile', 'npx projen test'].join('\n'),
+      },
+      {
+        name: 'Check Rosetta version',
+        run: `test $(npx ${JSII_ROSETTA} --version) = "\${{ matrix.rosetta }}"`,
+      }],
+    });
+  }
+
+  private calculateVersionConstraint(versions: RosettaPeerDependencyOptions['supportedVersions']): string {
+    const comparators = Object.values(versions).filter(Boolean).join(' || ');
+    return JSII_ROSETTA + '@' + comparators;
+  }
+
+  private calculateMinimalVersions(versions: RosettaPeerDependencyOptions['supportedVersions']): string[] {
+    const discoveredVersions = new Array<string>();
+    for (const comparator of Object.values(versions)) {
+      if (comparator) {
+        const minimum = minVersion(comparator)?.version;
+        if (minimum) {
+          discoveredVersions.push(minimum);
+        }
+      }
+    }
+
+    return discoveredVersions;
+  }
+}

--- a/test/generate-missing-examples.test.ts
+++ b/test/generate-missing-examples.test.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { SPEC_FILE_NAME, SPEC_FILE_NAME_COMPRESSED } from '@jsii/spec';
 
 import { LanguageTablet, TargetLanguage } from 'jsii-rosetta';
-import { DUMMY_ASSEMBLY_TARGETS, AssemblyFixture } from './testutil';
+import { DUMMY_ASSEMBLY_TARGETS, AssemblyFixture, DUMMY_ASSEMBLY_DEPS } from './testutil';
 import { generateMissingExamples } from '../src/generate-missing-examples';
 
 test('@aws-cdk/core special case', async () => {
@@ -26,6 +26,7 @@ test('@aws-cdk/core special case', async () => {
     {
       name: '@aws-cdk/core',
       jsii: DUMMY_ASSEMBLY_TARGETS,
+      jsiiRosetta: DUMMY_ASSEMBLY_DEPS,
     },
   );
   try {
@@ -60,6 +61,7 @@ test('test end-to-end and translation to Python', async () => {
     {
       name: 'my_assembly',
       jsii: DUMMY_ASSEMBLY_TARGETS,
+      jsiiRosetta: DUMMY_ASSEMBLY_DEPS,
     },
   );
   try {
@@ -113,6 +115,7 @@ test('test end-to-end and translation to Python with compressed assembly', async
     {
       name: 'my_assembly',
       jsii: DUMMY_ASSEMBLY_TARGETS,
+      jsiiRosetta: DUMMY_ASSEMBLY_DEPS,
     },
     {
       compressAssembly: true,

--- a/test/generate-missing-examples.test.ts
+++ b/test/generate-missing-examples.test.ts
@@ -6,6 +6,9 @@ import { LanguageTablet, TargetLanguage } from 'jsii-rosetta';
 import { DUMMY_ASSEMBLY_TARGETS, AssemblyFixture, DUMMY_ASSEMBLY_DEPS } from './testutil';
 import { generateMissingExamples } from '../src/generate-missing-examples';
 
+// these tests need to install an npm package
+jest.setTimeout(30000);
+
 test('@aws-cdk/core special case', async () => {
   const assembly = await AssemblyFixture.fromSource(
     {

--- a/test/testutil.ts
+++ b/test/testutil.ts
@@ -41,6 +41,7 @@ export class AssemblyFixture {
     fs.writeFileSync(path.join(modDir, 'package.json'), JSON.stringify({
       name: packageInfo.name,
       jsii: packageInfo.jsii,
+      jsiiRosetta: packageInfo.jsiiRosetta,
     }, null, 2));
     for (const [fileName, fileContents] of Object.entries(files)) {
       // eslint-disable-next-line no-await-in-loop
@@ -56,6 +57,11 @@ export class AssemblyFixture {
     fs.rmSync(this.directory, { recursive: true });
   }
 }
+export const DUMMY_ASSEMBLY_DEPS = {
+  exampleDependencies: {
+    constructs: '^10.0.0',
+  },
+};
 
 export const DUMMY_ASSEMBLY_TARGETS = {
   targets: {

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -23,7 +23,8 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2019"
+    "target": "ES2019",
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,8 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2019"
+    "target": "ES2019",
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*.ts"

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,7 +627,7 @@
     chalk "^4.1.2"
     semver "^7.5.4"
 
-"@jsii/spec@1.97.0", "@jsii/spec@^1.97.0":
+"@jsii/spec@^1.97.0":
   version "1.97.0"
   resolved "https://registry.yarnpkg.com/@jsii/spec/-/spec-1.97.0.tgz#951109ad43bdd7c1ea2de96a74e4fa645bd9a413"
   integrity sha512-5YIq1fgOtToH6eUyTNlqAXuZzUzTD6wBukE7m5DpsxHjQlbR7TVP750FcPqH9qCitCwaePPl5IdCZJ/AS0IwEA==
@@ -1402,15 +1402,15 @@ comment-json@4.2.2:
     has-own-prop "^2.0.0"
     repeat-string "^1.6.1"
 
-commonmark@^0.30.0:
-  version "0.30.0"
-  resolved "https://registry.yarnpkg.com/commonmark/-/commonmark-0.30.0.tgz#38811dc7bbf0f59d277ae09054d4d73a332f2e45"
-  integrity sha512-j1yoUo4gxPND1JWV9xj5ELih0yMv1iCWDG6eEQIPLSWLxzCXiFoyS7kvB+WwU+tZMf4snwJMMtaubV0laFpiBA==
+commonmark@^0.31.0:
+  version "0.31.0"
+  resolved "https://registry.yarnpkg.com/commonmark/-/commonmark-0.31.0.tgz#4ac57c61f0d7f5ef82d79447a972c61226ef5abc"
+  integrity sha512-nuDsQ34gjmgAqjyIz6mbRWBW/XPE9wsBempAMBk2V/AA88ekztjTM46oi07J6c6Y/2Y8TdYCZi9L0pIBt/oMZw==
   dependencies:
-    entities "~2.0"
+    entities "~3.0.1"
     mdurl "~1.0.1"
-    minimist ">=1.2.2"
-    string.prototype.repeat "^0.2.0"
+    minimist "~1.2.5"
+    string.prototype.repeat "^1.0.0"
 
 compare-func@^2.0.0:
   version "2.0.0"
@@ -1845,10 +1845,10 @@ enhanced-resolve@^5.12.0:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
 
-entities@~2.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
-  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
+entities@~3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
+  integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -1857,7 +1857,7 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.22.1, es-abstract@^1.22.3, es-abstract@^1.23.0, es-abstract@^1.23.2:
+es-abstract@^1.17.5, es-abstract@^1.22.1, es-abstract@^1.22.3, es-abstract@^1.23.0, es-abstract@^1.23.2:
   version "1.23.3"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.23.3.tgz#8f0c5a35cd215312573c5a27c87dfd6c881a0aa0"
   integrity sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==
@@ -3311,44 +3311,26 @@ jsii-reflect@^1.97.0:
     oo-ascii-tree "^1.97.0"
     yargs "^16.2.0"
 
-jsii-rosetta@^1.97.0:
-  version "1.97.0"
-  resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-1.97.0.tgz#2594da13829d848bc5895db2895cd17c64fc3582"
-  integrity sha512-cxHGvwMrH7lt+O24afEI2ljMbCOtTBCRwQU7Bia87nLkYNpysfFrrz+vUGZ1yi/7DOxhQShm1i4VGJJ8UhvEAg==
-  dependencies:
-    "@jsii/check-node" "1.97.0"
-    "@jsii/spec" "1.97.0"
-    "@xmldom/xmldom" "^0.8.10"
-    commonmark "^0.30.0"
-    fast-glob "^3.3.2"
-    jsii "1.97.0"
-    semver "^7.5.4"
-    semver-intersect "^1.4.0"
-    stream-json "^1.8.0"
-    typescript "~3.9.10"
-    workerpool "^6.5.1"
-    yargs "^16.2.0"
-
-jsii@1.97.0:
-  version "1.97.0"
-  resolved "https://registry.yarnpkg.com/jsii/-/jsii-1.97.0.tgz#5ceee9f1b4715b82e37ec5a24b509336d8ebef83"
-  integrity sha512-C3GA2Q50DkHnFozg7HKel7ZaBMCUKb/dzgH2ykfrbuJ/C/KebkPkqY/XRf95zGB42mzagPfawSLDFQiGGueQ9w==
+"jsii-rosetta@^1.85.0 || ~5.1.2 || ~5.2.0 || ~5.3.0 || ~5.4.0":
+  version "5.4.6"
+  resolved "https://registry.yarnpkg.com/jsii-rosetta/-/jsii-rosetta-5.4.6.tgz#ada3dd6218acb0e5960dbfc15e8b1f67e045ede8"
+  integrity sha512-RyTtc3hJmmrpbiWCLVvgHfy0Is4PWIYDy+Al6/d1xwZDq64DHJU6yU+H99SgL7LRLLwDyCod2QqRmZ1VIywwcQ==
   dependencies:
     "@jsii/check-node" "1.97.0"
     "@jsii/spec" "^1.97.0"
-    case "^1.6.3"
+    "@xmldom/xmldom" "^0.8.10"
     chalk "^4"
-    fast-deep-equal "^3.1.3"
-    fs-extra "^10.1.0"
-    log4js "^6.9.1"
-    semver "^7.5.4"
-    semver-intersect "^1.4.0"
-    sort-json "^2.0.1"
-    spdx-license-list "^6.8.0"
-    typescript "~3.9.10"
-    yargs "^16.2.0"
+    commonmark "^0.31.0"
+    fast-glob "^3.3.2"
+    jsii "~5.4.0"
+    semver "^7.6.0"
+    semver-intersect "^1.5.0"
+    stream-json "^1.8.0"
+    typescript "~5.4"
+    workerpool "^6.5.1"
+    yargs "^17.7.2"
 
-jsii@^5.4.6:
+jsii@^5.4.6, jsii@~5.4.0:
   version "5.4.6"
   resolved "https://registry.yarnpkg.com/jsii/-/jsii-5.4.6.tgz#5389695696d7d8fc8e34942c6efef97ef0236fe0"
   integrity sha512-Ohqz39ecBfmL/Pd5nnkERnikyOoZmNdqoSqedl+yXATM+js7XLlUGgQ+BdBXaO0rzQU2AEQ40C0COtF0jFXw4A==
@@ -3664,7 +3646,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@>=1.2.2, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6, minimist@~1.2.5:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -4256,7 +4238,7 @@ safe-regex-test@^1.0.3:
     es-errors "^1.3.0"
     is-regex "^1.1.4"
 
-semver-intersect@^1.4.0, semver-intersect@^1.5.0:
+semver-intersect@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/semver-intersect/-/semver-intersect-1.5.0.tgz#bb3aa0ea504935410d34cf15f49818d56906bd48"
   integrity sha512-BDjWX7yCC0haX4W/zrnV2JaMpVirwaEkGOBmgRQtH++F1N3xl9v7k9H44xfTqwl+yLNNSbMKosoVSTIiJVQ2Pw==
@@ -4404,7 +4386,7 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz#887da8aa73218e51a1d917502d79863161a93f9c"
   integrity sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==
 
-spdx-license-list@^6.8.0, spdx-license-list@^6.9.0:
+spdx-license-list@^6.9.0:
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/spdx-license-list/-/spdx-license-list-6.9.0.tgz#5543abb3a15f985a12808f642a622d2721c372ad"
   integrity sha512-L2jl5vc2j6jxWcNCvcVj/BW9A8yGIG02Dw+IUw0ZxDM70f7Ylf5Hq39appV1BI9yxyWQRpq2TQ1qaXvf+yjkqA==
@@ -4493,10 +4475,13 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string.prototype.repeat@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz#aba36de08dcee6a5a337d49b2ea1da1b28fc0ecf"
-  integrity sha512-1BH+X+1hSthZFW+X+JaUkjkkUPwIlLEMJBLANN3hOob3RhEk5snLWNECDnYbgn/m5c5JV7Ersu1Yubaf+05cIA==
+string.prototype.repeat@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz#e90872ee0308b29435aa26275f6e1b762daee01a"
+  integrity sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.5"
 
 string.prototype.trim@^1.2.9:
   version "1.2.9"
@@ -4814,11 +4799,6 @@ typescript@next:
   version "5.5.0-dev.20240426"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.0-dev.20240426.tgz#e9ba7d0b3cdaa54021faca61d1bc399e4766c93b"
   integrity sha512-96cu+y3DrjSNhNSgB3t3nRiesCwBVjZpbjJ6DcQoCgt0crXXPrOMmJQH/E8TZ41U4JzaULD+cB1Z2owh5HANew==
-
-typescript@~3.9.10:
-  version "3.9.10"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
-  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
 uglify-js@^3.1.4:
   version "3.17.4"


### PR DESCRIPTION
Previously this package had a hard dependency on jsii-rosetta 1.x. This is problematic if a different version of the jsii compiler was used, because it introduced different versions of TypeScript into the project.

With this PR, the dependency is changed to a peer dependency. Thus allowing any compatible version jsii-rosetta to be used.

BREAKING CHANGE: cdk-generate-synthetic-examples now has a peer dependency on jsii-rosetta. Please ensure a version of jsii-rosetta matching your version of jsii is available. Most package managers install peer dependencies automatically and no change is required. However users of yarn v1 or npm v3 to v6 must install jsii-rosetta manually.

