### PR TITLE
chore(deps): update node version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -95,7 +95,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Install dependencies
         run: yarn install --check-files
       - name: Install Rosetta version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
@@ -96,7 +96,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/upgrade-dev-deps-main.yml
+++ b/.github/workflows/upgrade-dev-deps-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -29,7 +29,7 @@ const project = new CdklabsTypeScriptProject({
   },
   releaseToNpm: true,
   gitignore: ['*.js', '*.d.ts'],
-  workflowNodeVersion: '18.x',
+  workflowNodeVersion: '20.x',
   enablePRAutoMerge: true,
   setNodeEngineVersion: false,
 });


### PR DESCRIPTION
The github action failed https://github.com/cdklabs/cdk-generate-synthetic-examples/actions/runs/12700868670/job/35453963893#step:5:48

```
error lru-cache@11.0.2: The engine "node" is incompatible with this module. Expected version "20 || >=22". Got "18.20.5"
```

This is to update the node version.