### PR TITLE
fix: escape 'scope' and 'id' when naming generated variables

### DIFF
--- a/src/module-utils.ts
+++ b/src/module-utils.ts
@@ -62,8 +62,21 @@ export function typeAccess(type: reflect.Type): TypeAccess {
 
 const KEYWORDS = ['function', 'default', 'arguments', 'enum'];
 
+/**
+ * Identifiers that are declared by the synthetic-example fixture.
+ *
+ * The generated examples are rendered inside the `_generated` fixture (see
+ * `generateFixture` in `generate-missing-examples.ts`), whose body sits inside
+ * `constructor(scope: Construct, id: string)`. A generated variable named
+ * `scope` or `id` (e.g. for a struct named `Scope` or `Id`) would therefore
+ * collide with those constructor parameters and fail to compile with
+ * "Duplicate identifier" under rosetta strict mode. Escaping them keeps the
+ * generated code compiling.
+ */
+const FIXTURE_RESERVED_IDENTIFIERS = ['scope', 'id'];
+
 export function escapeIdentifier(ident: string): string {
-  return KEYWORDS.includes(ident) ? `${ident}_` : ident;
+  return KEYWORDS.includes(ident) || FIXTURE_RESERVED_IDENTIFIERS.includes(ident) ? `${ident}_` : ident;
 }
 
 /**

--- a/test/generate.test.ts
+++ b/test/generate.test.ts
@@ -306,6 +306,29 @@ describe('generateClassAssignment ', () => {
 });
 
 test(
+  'generate example for struct named Scope does not collide with fixture params',
+  expectedDocTest({
+    sources: {
+      'index.ts': `
+      export interface Scope {
+        readonly required: string;
+      }
+      `,
+    },
+    typeName: 'Scope',
+    // A variable named 'scope' would collide with the synthetic fixture's
+    // `constructor(scope, id)`, so it must be escaped to 'scope_'.
+    expected: [
+      'import * as my_assembly from \'my_assembly\';',
+      '',
+      'const scope_: my_assembly.Scope = {',
+      '  required: \'required\',',
+      '};',
+    ],
+  }),
+);
+
+test(
   'generate example for struct',
   expectedDocTest({
     sources: {

--- a/test/module-utils.test.ts
+++ b/test/module-utils.test.ts
@@ -1,7 +1,26 @@
 import * as reflect from 'jsii-reflect';
 import { AssemblyFixture, DUMMY_ASSEMBLY_TARGETS } from './testutil';
 import { DirTrackingTypeSystem } from '../src/dir-tracking-typesystem';
-import { typeAccess } from '../src/module-utils';
+import { escapeIdentifier, typeAccess } from '../src/module-utils';
+
+describe('escapeIdentifier', () => {
+  test('escapes fixture-reserved identifiers so they cannot collide with the fixture constructor params', () => {
+    // The synthetic-example fixture renders the example inside
+    // `constructor(scope: Construct, id: string)`, so these must be escaped.
+    expect(escapeIdentifier('scope')).toEqual('scope_');
+    expect(escapeIdentifier('id')).toEqual('id_');
+  });
+
+  test('escapes reserved TypeScript keywords', () => {
+    expect(escapeIdentifier('function')).toEqual('function_');
+    expect(escapeIdentifier('default')).toEqual('default_');
+  });
+
+  test('leaves ordinary identifiers untouched', () => {
+    expect(escapeIdentifier('bucket')).toEqual('bucket');
+    expect(escapeIdentifier('scopeName')).toEqual('scopeName');
+  });
+});
 
 describe('v1 names are correct: ', () => {
   test('core', async () => {


### PR DESCRIPTION
## What

`escapeIdentifier()` now also escapes the identifiers `scope` and `id` (rendering them as `scope_` / `id_`), in addition to the existing reserved TypeScript keywords.

## Why

Synthetic examples are rendered inside the tool's generated `_generated` fixture, whose body sits inside:

```ts
class MyConstruct extends Construct {
  constructor(scope: Construct, id: string) {
    super(scope, id);
    /// here
  }
}
```

`generateAssignmentStatement()` names the top-level example variable `lowercaseFirstLetter(type.name)`. For a struct or class named `Scope` (or `Id`), that produces `const scope = ...` (or `const id = ...`) injected into the constructor above, which collides with the `scope` / `id` parameters:

```
error TS2300: Duplicate identifier 'scope'.
```

Under rosetta strict mode this is fatal and fails packaging. This surfaced in `aws-cdk` for `@aws-cdk/mixins-preview`, which generates DataExchange event structs named `Scope`, breaking the `pack.sh` rosetta step.

Every generated variable name flows through `escapeIdentifier` (the top-level example variable and assumed-variable declarations), so escaping `scope`/`id` there fixes the collision in all cases.

## Testing

- Unit test in `test/module-utils.test.ts`: `escapeIdentifier` maps `scope`→`scope_`, `id`→`id_`, keeps keyword escaping, and leaves ordinary identifiers untouched.
- Integration test in `test/generate.test.ts`: a struct named `Scope` renders `const scope_: my_assembly.Scope = { ... }`.
- Full `projen build` passes (all tests + eslint).
- Verified end to end against the real `@aws-cdk/mixins-preview` assembly: the generated `DataSetUpdateDelayed.Scope` example is now `const scope_: ...`, so the duplicate-identifier error is gone.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.